### PR TITLE
Removing Masterminds/goutils from go.mod

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,14 +12,20 @@ The recommended PR process is as follows.
 2. Upgrade with `go get -u github.com/jackskj/carta`
 3. cd `$GOPATH/src/github.com/jackskj/carta`
 4. Reflect your changes in example files as well as the README. 
-5. You can use gazelle functions (gazelle, repos, and fix) from the Makefile. 
-6. Make sure that the build succedes with `go build` or `make build` 
+5. Make sure that the build succedes with `go build` or `make build`
    and all tests pass with `make test`
-7. Make sure to follow [Effective Go](https://golang.org/doc/effective_go.html)  
+6. Make sure to follow [Effective Go](https://golang.org/doc/effective_go.html)
    as well as [Go Code Review Comments](https://golang.org/wiki/CodeReviewComments)
 
-## Code of Conduct
 
+## Testing
+Go tests can be run via make by executing `make test`.
+
+Prior to running unit tests, ensure postgres and mysql database containers are running by executing `make testdbs`.
+
+Before running `make test` for the first time, you will need to create the database structure by running `make initdb`.
+
+## Code of Conduct
 
 Please do not make aggressive, harassing or condescending comments based on someone's
 age, body size, disability, ethnicity, gender identity and expression, level of experience,

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ install:
 	# generating map binary in $$GOPATH/bin
 	go install .
 
+initdb:
+	go test -v -initdb
+
 test:
 	go test -v
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/jackskj/carta
 go 1.14
 
 require (
-	github.com/Masterminds/goutils v1.1.0 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/go-sql-driver/mysql v1.5.0


### PR DESCRIPTION
Masterminds/goutils isn't a direct dependency for carta but indirect github.com/Masterminds/sprig in for testdata/initdb/server.go. goutils is currently being flagged by dependabot - https://github.com/advisories/GHSA-xg2h-wx96-xgxr.

Alternately - could bump goutils to v1.1.1, but as mentioned I seem to be able to build/test without it.

Also cleaned up contributing doc a little and added initdb make target

(I'm breaking my rule of a PR focusing on one specific thing - if you want Makefile and CONTRIBUTORS.md in a separate PR, lemme know.)